### PR TITLE
tests: throw errors & -r=7 & unexpected error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -23,7 +23,6 @@ module.exports = async () => {
 	    spinner.text = `${nameWithVersion} copied to ${targetDir} in ${timer.get()}. Have fun!`;
     }catch(err){
         await fs.remove(tempDir);
-        /* istanbul ignore else */
         if(err.code === 'ETARGET'){
             const msg = chalk.red(`version '${err.wanted}' not found in npm registry\navailable versions:\n`)
             spinner.fail(msg+err.versions.reverse().join(' | '));

--- a/cli.js
+++ b/cli.js
@@ -23,16 +23,14 @@ module.exports = async () => {
 	    spinner.text = `${nameWithVersion} copied to ${targetDir} in ${timer.get()}. Have fun!`;
     }catch(err){
         await fs.remove(tempDir);
+        /* istanbul ignore else */
         if(err.code === 'ETARGET'){
-            spinner.fail(chalk.red(`version '${err.wanted}' not found in npm registry\navailable versions:`));
-            console.log(err.versions.reverse().join(' | '));
-            process.exit(1);
-        }/* istanbul ignore next */else{
-            spinner.fail('Unexpected error');
-            console.error(err);
-            process.exit(-1);
-        };
-        return;
+            const msg = chalk.red(`version '${err.wanted}' not found in npm registry\navailable versions:\n`)
+            spinner.fail(msg+err.versions.reverse().join(' | '));
+            throw err.code;
+        }
+        spinner.fail('Unexpected error');
+        throw new Error(err);
     }
     await fs.copy(tempDir+'/dist', targetDir);
     await fs.remove(tempDir);

--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-require('./cli')();
+require('./cli')().catch(console.error);

--- a/tests/test.js
+++ b/tests/test.js
@@ -24,6 +24,7 @@ const all_versions = [
 const cases = [
   null,
   "-r=latest",
+  "-r=7",
   "-r=7.2.0",
   "-r=v7.2.0",
   "-r=v7.2",
@@ -112,13 +113,26 @@ describe.each(cases)("Downloading %s", (version) => {
 
 describe("Errors", () => {
   test("Wrong version 6..2.3", async () => {//maybe create test.each() for more errors scenarios
-    const mockExit = jest.spyOn(process, "exit").mockImplementation(() => {});
     const version = "-r=6..2.3";
+    try{
+      await runCli(version);
+    }catch(err){
+      expect(err).toBe('ETARGET');
+    }finally{
+      await fs.remove(versionFolder(version));
+    }
+  });
+});
 
-    await runCli(version);
-
-    await fs.remove(versionFolder(version));
-    expect(mockExit).toHaveBeenCalledWith(1);
-    mockExit.mockRestore();
+describe("Unexpected errors", () => {
+  test("Unexpected error 6..2.3,7.2.3", async () => {//maybe create test.each() for more errors scenarios
+    const version = "-r=6..2.3,7.2.3";
+    try{
+      await runCli(version);
+    }catch(err){
+      expect(err).not.toBe('ETARGET');
+    }finally{
+      await fs.remove(versionFolder(version));
+    }
   });
 });


### PR DESCRIPTION
- Unexpected error test (istanbul ignore removed) by passing -r=x.x.x**,**x.x.x
- Throw errors instead of `process.exit()`
- Catch error in `index.js` (removes warning `unhandledPromiseRejectionWarning`)