### PR TITLE
Add 'files' to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,12 @@
     "coverage": "jest --coverage --collectCoverageOnlyFrom ./cli.js",
     "start": "node ./index.js ./out"
   },
+  "files": [
+    "license.txt",
+    "index.js",
+    "cli.js",
+    "README.md"
+  ],
   "dependencies": {
     "chalk": "^4.0.0",
     "elapsed-time-logger": "^1.1.2",


### PR DESCRIPTION
I was concidering to add `.npmignore`, but I think `files` setting in `package.json` is better. 
Actually not sure what is the benefits of `.npmignore`, from fast googling I understood that its [bad practice](https://medium.com/@jdxcode/for-the-love-of-god-dont-use-npmignore-f93c08909d8d). Am i missing something?
```json
"files": [
    "license.txt",
    "index.js",
    "cli.js",
    "README.md"
  ]`
```
before:
![image](https://user-images.githubusercontent.com/5851280/82346662-6d702e00-99ff-11ea-943e-542e7b7b93f7.png)

after:
![image](https://user-images.githubusercontent.com/5851280/82346626-5d584e80-99ff-11ea-9d89-22064e9c5c4c.png)
