### PR TITLE
ci: test on node 10 and 14

### DIFF
--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [10.x, 12.x, 14.x]
 
     steps:
       - name: Get npm cache directory


### PR DESCRIPTION
Guess we should run tests on the current (14) version and 10.
Maybe even test on node 6?

as this is what we write in the readme:
> works wherever node and npm work. The only requirements are for npx, which requires npm version 5.2 or greater and npm init which requires an npm version greater than 6.0.